### PR TITLE
Fixed #12: "No test report files were found. Configuration error?"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ pipeline {
             // Optional: Archive test results (e.g., JUnit format)
             post {
                 always {
-                    junit 'build/test-results/test/**/*.xml'
+                    junit '**/build/test-results/test/*.xml'
                 }
             }
         }


### PR DESCRIPTION
Проблема в том, что Jenkins ищет отчёты тестов не там, где они реально лежат в multi-module проекте. Jenkins ищет только
```
:build/test-results/test/**/*.xml
```
То есть в root-модуле.
Нужно искать во всех подпроектах:
```
junit '**/build/test-results/test/*.xml'
```